### PR TITLE
feat: fmt command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "similar",
  "strip-ansi-escapes",
  "tempfile",
+ "term_size",
 ]
 
 [[package]]
@@ -433,6 +434,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.210", features = ["derive"] }
 peg = "0.8.4"
 chumsky = "0.9.3"
 similar = "2.6.0"
+term_size = "0.3.2"
 
 [dev-dependencies]
 strip-ansi-escapes = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ pub fn delete_env_vars(
     Ok(updated_lines)
 }
 
-pub fn format_env_file(content: &str) -> Result<Vec<parser::Line>, std::io::Error> {
+pub fn format_env_file(content: &str, prune: bool) -> Result<Vec<parser::Line>, std::io::Error> {
     let lines = parser::parser().parse(content).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -262,7 +262,12 @@ pub fn format_env_file(content: &str) -> Result<Vec<parser::Line>, std::io::Erro
 
     let mut key_value_lines: Vec<parser::Line> = lines
         .into_iter()
-        .filter(|line| !matches!(line, parser::Line::KeyValue { value, .. } if value.is_empty()))
+        .filter(|line| {
+            match line {
+                parser::Line::KeyValue { value, .. } => !value.is_empty(),
+                parser::Line::Comment(_) => !prune,
+            }
+        })
         .collect();
 
     key_value_lines.sort_by(|a, b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,11 +262,9 @@ pub fn format_env_file(content: &str, prune: bool) -> Result<Vec<parser::Line>, 
 
     let mut key_value_lines: Vec<parser::Line> = lines
         .into_iter()
-        .filter(|line| {
-            match line {
-                parser::Line::KeyValue { value, .. } => !value.is_empty(),
-                parser::Line::Comment(_) => !prune,
-            }
+        .filter(|line| match line {
+            parser::Line::KeyValue { value, .. } => !value.is_empty(),
+            parser::Line::Comment(_) => !prune,
         })
         .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,30 @@ pub fn delete_env_vars(
     Ok(updated_lines)
 }
 
+pub fn format_env_file(content: &str) -> Result<Vec<parser::Line>, std::io::Error> {
+    let lines = parser::parser().parse(content).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Error parsing .env file: {:?}", e),
+        )
+    })?;
+
+    let mut key_value_lines: Vec<parser::Line> = lines
+        .into_iter()
+        .filter(|line| !matches!(line, parser::Line::KeyValue { value, .. } if value.is_empty()))
+        .collect();
+
+    key_value_lines.sort_by(|a, b| {
+        if let (parser::Line::KeyValue { key: key_a, .. }, parser::Line::KeyValue { key: key_b, .. }) = (a, b) {
+            key_a.cmp(key_b)
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+
+    Ok(key_value_lines)
+}
+
 fn needs_quoting(value: &str) -> bool {
     value.chars().any(|c| {
         c.is_whitespace()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,11 @@ pub fn format_env_file(content: &str) -> Result<Vec<parser::Line>, std::io::Erro
         .collect();
 
     key_value_lines.sort_by(|a, b| {
-        if let (parser::Line::KeyValue { key: key_a, .. }, parser::Line::KeyValue { key: key_b, .. }) = (a, b) {
+        if let (
+            parser::Line::KeyValue { key: key_a, .. },
+            parser::Line::KeyValue { key: key_b, .. },
+        ) = (a, b)
+        {
             key_a.cmp(key_b)
         } else {
             std::cmp::Ordering::Equal

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,10 @@ fn print_diff(old_content: &str, new_content: &str, use_color: bool) {
                 ChangeTag::Delete => {
                     let line = change.to_string();
                     let padding = " ".repeat(term_width.saturating_sub(line.trim_end().len()));
-                    print!("{}", (line.trim_end().to_string() + &padding).on_bright_red());
+                    print!(
+                        "{}",
+                        (line.trim_end().to_string() + &padding).on_bright_red()
+                    );
                     println!();
                 }
                 ChangeTag::Insert => print!("{}", change.to_string().trim_end().on_bright_green()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,16 @@ fn print_diff(old_content: &str, new_content: &str, use_color: bool) {
                     );
                     println!();
                 }
-                ChangeTag::Insert => print!("{}", change.to_string().trim_end().on_bright_green()),
+                ChangeTag::Insert => {
+                    let line = change.to_string();
+                    let padding = " ".repeat(term_width.saturating_sub(line.trim_end().len()));
+                    print!(
+                        "{}",
+                        (line.trim_end().to_string() + &padding).on_bright_green()
+                    );
+                    println!();
+                }
                 ChangeTag::Equal => print!("{}", change),
-            }
-            // Print a newline after each colored line
-            if change.tag() == ChangeTag::Insert {
-                println!();
             }
         } else {
             let sign = match change.tag() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn print_diff(old_content: &str, new_content: &str, use_color: bool) {
                 ChangeTag::Delete => {
                     let line = change.to_string();
                     let padding = " ".repeat(term_width.saturating_sub(line.trim_end().len()));
-                    print!("{}", (line.trim_end().to_string() + &padding).on_red());
+                    print!("{}", (line.trim_end().to_string() + &padding).on_bright_red());
                     println!();
                 }
                 ChangeTag::Insert => print!("{}", change.to_string().trim_end().on_bright_green()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,16 +13,22 @@ use envset::{
 
 fn print_diff(old_content: &str, new_content: &str, use_color: bool) {
     let diff = TextDiff::from_lines(old_content, new_content);
+    let term_width = term_size::dimensions().map(|(w, _)| w).unwrap_or(80);
 
     for change in diff.iter_all_changes() {
         if use_color {
             match change.tag() {
-                ChangeTag::Delete => print!("{}", change.to_string().trim_end().on_bright_red()),
+                ChangeTag::Delete => {
+                    let line = change.to_string();
+                    let padding = " ".repeat(term_width.saturating_sub(line.trim_end().len()));
+                    print!("{}", (line.trim_end().to_string() + &padding).on_red());
+                    println!();
+                }
                 ChangeTag::Insert => print!("{}", change.to_string().trim_end().on_bright_green()),
                 ChangeTag::Equal => print!("{}", change),
             }
             // Print a newline after each colored line
-            if change.tag() != ChangeTag::Equal {
+            if change.tag() == ChangeTag::Insert {
                 println!();
             }
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,11 @@ enum Commands {
         keys: Vec<String>,
     },
     /// Format the .env file (sort keys and remove empty lines)
-    Fmt,
+    Fmt {
+        /// Remove whole line comments
+        #[arg(short = 'p', long = "prune")]
+        prune: bool,
+    },
 }
 
 fn main() {
@@ -161,8 +165,8 @@ fn main() {
                 process::exit(1);
             }
         },
-        Some(Commands::Fmt) => match read_env_file_contents(&cli.file) {
-            Ok(old_content) => match envset::format_env_file(&old_content) {
+        Some(Commands::Fmt { prune }) => match read_env_file_contents(&cli.file) {
+            Ok(old_content) => match envset::format_env_file(&old_content, *prune) {
                 Ok(formatted_lines) => {
                     let mut buffer = Vec::new();
                     if let Err(e) = print_env_file_contents(&formatted_lines, &mut buffer) {


### PR DESCRIPTION
formats .env files by sorting keys and removing whitespace. --prune flag also removes whole line comments
